### PR TITLE
Fix typo in README example explanation

### DIFF
--- a/bonsoir/README.md
+++ b/bonsoir/README.md
@@ -41,7 +41,7 @@ await broadcast.start();
 await broadcast.stop();
 ```
 
-And here is how you can broadcast your service :
+And here is how you can search for a broadcasted service :
 
 ```dart
 // This is the type of service we're looking for :


### PR DESCRIPTION
I think the second example explains how to search for a service rather than broadcast? Otherwise both examples say "here is how you can broadcast", which is confusing.