### PR TITLE
fix attributes value is covered to "Optional()" on iOS

### DIFF
--- a/bonsoir/darwin/Classes/SwiftBonsoirPlugin.swift
+++ b/bonsoir/darwin/Classes/SwiftBonsoirPlugin.swift
@@ -111,7 +111,7 @@ public class SwiftBonsoirPlugin: NSObject, FlutterPlugin {
         var result: [String: Data] = [:]
         for (key, value) in attributes {
             if(value != nil) {
-                result[key] = String(describing: value).data(using: .utf8)
+                result[key] = String(describing: value!).data(using: .utf8)
             }
         }
         return result


### PR DESCRIPTION
In BonsoirDiscoveryEvent, `event.service.attributes` value is covered to "Optional"

```dart
_bonsoirDiscovery?.eventStream?.listen(_onEventOccurred)

void _onEventOccurred(BonsoirDiscoveryEvent event) async {
    if (event.service == null || !event.isServiceResolved) {
      return;
    }
    print(event.service);

    ....
}
```

## Actual

value in attribute is include "Optional"

```
flutter:  {"service.name":"iPhone 11 Pro","service.type":"_http._tcp.","service.port":4000,"service.attributes":{"localizedModel":"Optional(\"iPhone\")","model":"Optional(\"iPhone\")"},"service.ip":"127.0.0.1"}
```


## Expected

should not be include "Optional"
```
flutter: {"service.name":"iPhone 11 Pro","service.type":"_http._tcp.","service.port":4000,"service.attributes":{"localizedModel":"iPhone","model":"iPhone"},"service.ip":"127.0.0.1"}
```