### PR TITLE
filter link local addresses from resolved set

### DIFF
--- a/bonsoir/darwin/Classes/SuccessObject.swift
+++ b/bonsoir/darwin/Classes/SuccessObject.swift
@@ -96,8 +96,10 @@ class SuccessObject {
                 }
 
                 if let ip = String(cString: inet_ntoa(addr4.sin_addr), encoding: .ascii) {
-                    result = ip
-                    break
+                    if (!ip.starts(with: "169")) {
+                        result = ip
+                        break
+                    }
                 }
             }
         }


### PR DESCRIPTION
Maybe in the future this should return an array of addresses instead of just one, provides more flexibility to the user.