### PR TITLE
Fix: Miss early discovery events

### DIFF
--- a/bonsoir/README.md
+++ b/bonsoir/README.md
@@ -50,7 +50,6 @@ String type = '_wonderful-service._tcp';
 // Once defined, we can start the discovery :
 BonsoirDiscovery discovery = BonsoirDiscovery(type: type);
 await discovery.ready;
-await discovery.start();
 
 // If you want to listen to the discovery :
 discovery.eventStream.listen((event) {
@@ -60,6 +59,9 @@ discovery.eventStream.listen((event) {
     print('Service lost : ${event.service.toJson()}')
   }
 });
+
+// Start discovery **after** having listened to discovery events
+await discovery.start();
 
 // Then if you want to stop the discovery :
 await discovery.stop();

--- a/bonsoir/test_suite/test_driver/app.dart
+++ b/bonsoir/test_suite/test_driver/app.dart
@@ -36,9 +36,10 @@ void main() {
           String service = 'ERROR';
           discovery = BonsoirDiscovery(type: type);
           await discovery.ready;
-          await discovery.start();
           await for(BonsoirDiscoveryEvent event in discovery.eventStream!) {
             if (event.type == BonsoirDiscoveryEventType.discoveryServiceResolved) {
+          await discovery
+              .start(); // Todo: In order to capture early discovery events, start needs to be called after listening to discovery events.
               service = jsonEncode(event.service!.toJson());
               break; 
             }


### PR DESCRIPTION
Fixed: When start() is called before listening, early discovery events are missed, and related services are not discovered.