### PR TITLE
fix: bonsoir_darwin pluginClass

### DIFF
--- a/bonsoir_darwin/pubspec.yaml
+++ b/bonsoir_darwin/pubspec.yaml
@@ -13,10 +13,10 @@ flutter:
     implements: bonsoir
     platforms:
       ios:
-        pluginClass: BonsoirPlugin
+        pluginClass: SwiftBonsoirPlugin
         sharedDarwinSource: true
       macos:
-        pluginClass: BonsoirPlugin
+        pluginClass: SwiftBonsoirPlugin
         sharedDarwinSource: true
 
 dependencies:


### PR DESCRIPTION
Updating the `pluginClass` definition for the iOS and macOS plugins to `SwiftBonsoirPlugin`.

Fixes #50 