### PR TITLE
Updated pubspec.yaml for bonsoir_android folder as it is giving error

### DIFF
--- a/bonsoir_android/pubspec.yaml
+++ b/bonsoir_android/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  bonsoir_platform_interface: ^2.2.0
+  bonsoir_platform_interface: ^3.0.0
 
 dependency_overrides:
   bonsoir_platform_interface:


### PR DESCRIPTION
```
Because bonsoir >=3.0.0 depends on bonsoir_android ^3.0.0 which depends on bonsoir_platform_interface ^2.2.0, bonsoir >=3.0.0 requires bonsoir_platform_interface ^2.2.0.
So, because mobileone depends on bonsoir ^3.0.0+1 which depends on bonsoir_platform_interface ^3.0.0, version solving failed.
```

Error when flutter pub get is fired