### PR TITLE
fix: support unascii character for TxtRecord on darwin

### DIFF
--- a/packages/bonsoir_darwin/darwin/Classes/Broadcast/BonsoirServiceBroadcast.swift
+++ b/packages/bonsoir_darwin/darwin/Classes/Broadcast/BonsoirServiceBroadcast.swift
@@ -26,7 +26,8 @@ class BonsoirServiceBroadcast: BonsoirAction {
         var txtRecord = TXTRecordRef()
         TXTRecordCreate(&txtRecord, 0, nil)
         for (key, value) in service.attributes {
-            TXTRecordSetValue(&txtRecord, key, UInt8(value.count), value)
+            guard let valueData = value.data(using: .utf8) else { continue }
+            TXTRecordSetValue(&txtRecord, key, UInt8(valueData.count), [UInt8](valueData))
         }
         let error = DNSServiceRegister(&sdRef, 0, 0, service.name, service.type, "local.", service.host, CFSwapInt16HostToBig(UInt16(service.port)), TXTRecordGetLength(&txtRecord), TXTRecordGetBytesPtr(&txtRecord), BonsoirServiceBroadcast.registerCallback as DNSServiceRegisterReply, Unmanaged.passUnretained(self).toOpaque())
         if error == kDNSServiceErr_NoError {


### PR DESCRIPTION
This PR fixes https://github.com/Skyost/Bonsoir/issues/90
It's seems unascii characters not be encode correctlly,  just encode TxtRecord value to [UInt8] with .utf8 formate solves this problem.