### PR TITLE
fix: Disabled constexpr mutex constructor to fix Windows build crashes.

### DIFF
--- a/packages/bonsoir_windows/windows/CMakeLists.txt
+++ b/packages/bonsoir_windows/windows/CMakeLists.txt
@@ -8,6 +8,9 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "bonsoir_windows")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
+# Deal with MSVC incompatiblity
+add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+
 # This value is used when generating builds using this plugin, so it must
 # not be changed
 set(PLUGIN_NAME "bonsoir_windows_plugin")


### PR DESCRIPTION
Some systems (like the github hosted runners) have recently changed default build system for windows builds and something breaks the entire system.


> 
> Seems like an issue in `msvcp140!mtx_do_lock+0x9c` is the culprit in both traces. After [some quick research](https://stackoverflow.com/questions/44998460/c-stdmutex-lock-access-violation-in-visual-studio-2017#44998776) it seems like maybe the mutex isn't being initialized properly? Though admittedly my knowledge in c++ is limited so I could be mistaken.
> 
> As for why this is seems to be behaving differently when being built locally vs on github actions, I believe [this](https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio) may be able to explain it.
> 
> > * Fixed `mutex`'s constructor to be `constexpr`. [#3824](https://github.com/microsoft/STL/pull/3824) [#4000](https://github.com/microsoft/STL/pull/4000) [#4339](https://github.com/microsoft/STL/pull/4339)
> >   
> >   * _Note:_ Programs that aren't following the documented [restrictions on binary compatibility](https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-170) may encounter null dereferences in `mutex` machinery. You **must** follow this rule:
> >     > When you mix binaries built by different supported versions of the toolset, the Redistributable version must be at least as new as the latest toolset used by any app component.
> >   * You can define `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` as an escape hatch.
> 
> --- [microsoft/STL changelog](https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710)
--- [MPV issue 892](https://github.com/media-kit/media-kit/issues/892)

The proposed fix explained in the issue above also works for this project