### PR TITLE
Allow for use of meta-query

### DIFF
--- a/packages/bonsoir_linux/lib/src/actions/discovery/discovery.dart
+++ b/packages/bonsoir_linux/lib/src/actions/discovery/discovery.dart
@@ -43,6 +43,9 @@ class AvahiBonsoirDiscovery extends AvahiBonsoirAction<BonsoirDiscoveryEvent> wi
           logMessages: BonsoirPlatformInterfaceLogMessages.discoveryMessages,
         );
 
+  // This returns whether the service is a meta query.
+  bool get isMetaQuery => type == bonsoirMetaQuery;
+
   @override
   Future<void> get ready async {
     if (_serviceBrowser == null) {
@@ -146,7 +149,7 @@ class AvahiBonsoirDiscovery extends AvahiBonsoirAction<BonsoirDiscoveryEvent> wi
   /// Triggered when a service has been found.
   Future<void> _onServiceFound(DBusSignal signal) async {
     AvahiServiceBrowserItemNew event = AvahiServiceBrowserItemNew(signal);
-    if (event.type != this.type) {
+    if (event.type != this.type && !isMetaQuery) {
       return;
     }
     BonsoirService? service = _findService(event.serviceName, event.type);

--- a/packages/bonsoir_platform_interface/lib/src/platform_interface.dart
+++ b/packages/bonsoir_platform_interface/lib/src/platform_interface.dart
@@ -37,8 +37,15 @@ abstract class BonsoirPlatformInterface extends PlatformInterface {
 /// A Bonsoir class that allows to either broadcast a service or to discover services on the network using a method channel.
 class MethodChannelBonsoir extends BonsoirPlatformInterface {
   @override
-  BonsoirAction<BonsoirBroadcastEvent> createBroadcastAction(BonsoirService service, {bool printLogs = kDebugMode}) => MethodChannelBonsoirBroadcastAction(service: service, printLogs: printLogs);
+  BonsoirAction<BonsoirBroadcastEvent> createBroadcastAction(BonsoirService service, {bool printLogs = kDebugMode}) =>
+      MethodChannelBonsoirBroadcastAction(service: service, printLogs: printLogs);
 
   @override
-  BonsoirAction<BonsoirDiscoveryEvent> createDiscoveryAction(String type, {bool printLogs = kDebugMode}) => MethodChannelBonsoirDiscoveryAction(type: type, printLogs: printLogs);
+  BonsoirAction<BonsoirDiscoveryEvent> createDiscoveryAction(String type, {bool printLogs = kDebugMode}) =>
+      MethodChannelBonsoirDiscoveryAction(type: type, printLogs: printLogs);
 }
+
+/// The DNS-SD meta query.
+///
+/// Reference : [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-9).
+const String bonsoirMetaQuery = '_services._dns-sd._udp';

--- a/packages/bonsoir_platform_interface/lib/src/service/normalizer.dart
+++ b/packages/bonsoir_platform_interface/lib/src/service/normalizer.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:bonsoir_platform_interface/src/platform_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /// Contains various methods that helps conforming to RFC 6335 and RFC 6763.
@@ -37,6 +38,11 @@ class BonsoirServiceNormalizer {
   /// * [RFC 6335](https://datatracker.ietf.org/doc/html/rfc6335#section-5.1);
   /// * [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-7).
   static String normalizeType(String type) {
+    // If the type is the meta query, we return it as is.
+    if (type == bonsoirMetaQuery) {
+      return type;
+    }
+
     List<String> parts = type.split('.');
     if (parts.length != 2) {
       return defaultServiceType;
@@ -88,7 +94,7 @@ class BonsoirServiceNormalizer {
   /// Normalizes a given service [attributes].
   ///
   /// Reference : [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-6).
-  static Map<String, String> normalizeAttributes(Map<String, String> attributes, { bool limitKeyLength = false }) {
+  static Map<String, String> normalizeAttributes(Map<String, String> attributes, {bool limitKeyLength = false}) {
     Map<String, String> result = <String, String>{};
 
     for (MapEntry<String, String> entry in attributes.entries) {


### PR DESCRIPTION
Hi,

As discussed in #86, it is normally possible to use the meta-query `_services._dns-sd._udp` to scan for every available services on the network. Enabling to then scan/discover every services and devices on the network. But it is currently not possible due to two things:

1. The `normalizeType` function that doesn't allow the specific query.
2. The platform specific implementations that are unable to deal with this specific case.

This PR fixes the first problem and also the platform implementation for Linux. I'm currently working on getting it to work for Android. But I won't be able to do it for Apple devices. 

I'm waiting to hear back from you regarding this PR.

-> Fixes #86 