### PR TITLE
fix(linux): don't parse attribute that doesn't contain '='

### DIFF
--- a/packages/bonsoir_linux/lib/src/actions/discovery/discovery.dart
+++ b/packages/bonsoir_linux/lib/src/actions/discovery/discovery.dart
@@ -198,7 +198,7 @@ class AvahiBonsoirDiscovery extends AvahiBonsoirAction<BonsoirDiscoveryEvent> wi
       host: event.address,
       port: event.port,
       attributes: Map.fromEntries(
-        event.txt.map((entry) {
+        event.txt.where((entry) => entry.contains('=')).map((entry) {
           int index = entry.indexOf('=');
           return MapEntry<String, String>(entry.substring(0, index), entry.substring(index + 1, entry.length));
         }),


### PR DESCRIPTION
If a txt record contains no '=' then the substring extraction fails with the error `RangeError (end): Invalid value: Not in inclusive range 0..1: -1`.