### PR TITLE
fix: Properly clean up service resolve queries on Windows

### DIFF
--- a/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
@@ -57,15 +57,15 @@ namespace bonsoir_windows {
 
     auto queryName = toUtf16(servicePtr->name + "." + servicePtr->type + ".local");
     DNS_SERVICE_RESOLVE_REQUEST resolveRequest{};
-    DNS_SERVICE_CANCEL resolveCancelHandle{};
+    DNS_SERVICE_CANCEL* resolveCancelHandle = new DNS_SERVICE_CANCEL; // Dynamically allocate so it can be used during dispose()
     resolveRequest.Version = DNS_QUERY_REQUEST_VERSION1;
     resolveRequest.InterfaceIndex = 0;
     resolveRequest.QueryName = const_cast<PWSTR>(queryName.c_str());
     resolveRequest.pResolveCompletionCallback = resolveCallback;
     resolveRequest.pQueryContext = this;
-    DNS_STATUS status = DnsServiceResolve(&resolveRequest, &resolveCancelHandle);
+    DNS_STATUS status = DnsServiceResolve(&resolveRequest, resolveCancelHandle);
     if (status == DNS_REQUEST_PENDING) {
-      resolvingServices[servicePtr] = &resolveCancelHandle;
+      resolvingServices[servicePtr] = resolveCancelHandle;
     } else {
       onSuccess(Generated::discoveryServiceResolveFailed, servicePtr, std::list<std::string>{std::to_string(status)});
     }
@@ -76,6 +76,7 @@ namespace bonsoir_windows {
     onSuccess(Generated::discoveryStopped, nullptr, std::list<std::string>{type});
     for (auto const &[key, value] : resolvingServices) {
       DnsServiceResolveCancel(value);
+      delete value; // Allocated in resolveService()
     }
     resolvingServices.clear();
     services.clear();
@@ -179,6 +180,8 @@ namespace bonsoir_windows {
       servicePtr->port = serviceInstance->wPort;
       DnsServiceFreeInstance(serviceInstance);
     }
+    DNS_SERVICE_CANCEL* serviceCancelHandle = discovery->resolvingServices[servicePtr];
+    delete serviceCancelHandle; // Allocated in resolveService()
     discovery->resolvingServices.erase(servicePtr);
     discovery->onSuccess(Generated::discoveryServiceResolved, servicePtr);
   }

--- a/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
@@ -180,8 +180,8 @@ namespace bonsoir_windows {
       servicePtr->port = serviceInstance->wPort;
       DnsServiceFreeInstance(serviceInstance);
     }
-    DNS_SERVICE_CANCEL* serviceCancelHandle = discovery->resolvingServices[servicePtr];
-    delete serviceCancelHandle; // Allocated in resolveService()
+    DNS_SERVICE_CANCEL* resolveCancelHandle = discovery->resolvingServices[servicePtr];
+    delete resolveCancelHandle; // Allocated in resolveService()
     discovery->resolvingServices.erase(servicePtr);
     discovery->onSuccess(Generated::discoveryServiceResolved, servicePtr);
   }


### PR DESCRIPTION
This PR fixes a bug where DNS resolve queries were not being properly cancelled, which ended up causing a crash in some scenarios.

The Windows implementation of `BonsoirDiscovery::dispose` calls `DnsServiceResolveCancel` to cancel any DNS resolve queries that are still running. However, the `DNS_SERVICE_CANCEL` structs stored in `resolvingServices` are statically allocated during `BonsoirDiscovery::resolveService`, so they are out of scope when `dispose` gets called. Since the memory being used is no longer valid, the call to `DnsServiceResolveCancel` fails with the error `ERROR_INVALID_PARAMETER`, and the DNS resolve queries never get properly cancelled.

This is often not a big problem, but it can cause a silent crash in a specific situation: If the discovery process is restarted (by calling `BonsoirDiscovery.stop`, re-initializing the discovery, then calling `BonsoirDiscovery.start`) and the DNS resolution completes after the restart, the app crashes without any error messages. I assume the crash comes from the old DNS resolve query getting triggered by the OS

<details> 

<summary>Specific reproduction steps</Summary>

1. Start a Bonsoir discovery scan with `BonsoirDiscovery.initialize` and `start`

1. Power on a device that advertises over zeroconf

1. Once the service is found (`BonsoirDiscoveryServiceFoundEvent`), turn off the device that is advertising

1. Call `service.resolve` once the device is off. This is the DNS query that will cause the crash

1. Restart the scan: Call `BonsoirDiscovery.stop`, create a new `BonsoirDiscovery` object, call `BonsoirDiscovery.initialize` and `start`

1. Power on the same device to advertise over zeroconf

1. Once the advertisement is up and the service would normally be able to resolve, the app will crash without an error message

</details>

Dynamically allocating the `DNS_SERVICE_CANCEL` structs fixes the issue, since the call to `DnsServiceResolveCancel` succeeds. The dynamic memory is freed right after the call to query is cancelled (`dispose`) or when the resolution completes successfully (`resolveCallback`)