### PR TITLE
fix: Windows event dispatch threading

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto eol=lf
+
+# Windows scripts.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary assets.
+*.gif binary
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.png binary
+*.webp binary
+*.a binary
+*.dll binary
+*.dylib binary
+*.exe binary
+*.framework binary
+*.jar binary
+*.keystore binary
+*.p12 binary
+*.so binary
+*.xcframework binary

--- a/packages/bonsoir_windows/windows/bonsoir_action.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_action.cpp
@@ -9,6 +9,11 @@
 using namespace flutter;
 
 namespace bonsoir_windows {
+  namespace {
+    constexpr wchar_t kMessageWindowClassName[] = L"BonsoirWindowsEventMessageWindow";
+    std::once_flag gRegisterMessageWindowClassFlag;
+  }
+
   BonsoirAction::BonsoirAction(
     std::string _action,
     const std::map<std::string, std::string> _logMessages,
@@ -21,6 +26,22 @@ namespace bonsoir_windows {
       id(_id),
       eventChannel(std::make_unique<EventChannel<EncodableValue>>(_binaryMessenger, "fr.skyost.bonsoir." + _action + "." + std::to_string(id), &StandardMethodCodec::GetInstance())),
       printLogs(_printLogs) {
+    RegisterMessageWindowClass();
+    messageWindow = CreateWindowExW(
+      0,
+      kMessageWindowClassName,
+      L"",
+      0,
+      0,
+      0,
+      0,
+      0,
+      HWND_MESSAGE,
+      nullptr,
+      GetModuleHandle(nullptr),
+      this
+    );
+
     eventChannel->SetStreamHandler(
       std::make_unique<StreamHandlerFunctions<EncodableValue>>(
         [this](const EncodableValue *arguments, std::unique_ptr<EventSink<EncodableValue>> &&events)
@@ -53,6 +74,10 @@ namespace bonsoir_windows {
 
   void BonsoirAction::dispose() {
     stop();
+    if (messageWindow) {
+      DestroyWindow(messageWindow);
+      messageWindow = nullptr;
+    }
     if (eventChannel) {
       eventChannel->SetStreamHandler(nullptr);
       eventChannel = nullptr;
@@ -61,8 +86,13 @@ namespace bonsoir_windows {
 
   void BonsoirAction::onEvent(std::shared_ptr<EventObject> eventObjectPtr, std::list<std::string> parameters) {
     log(eventObjectPtr->message, parameters);
-    eventQueue.push(std::move(eventObjectPtr));
-    processEventQueue();
+    {
+      std::scoped_lock lock{mutex};
+      eventQueue.push(std::move(eventObjectPtr));
+    }
+    if (messageWindow) {
+      PostMessage(messageWindow, processEventQueueMessage, 0, 0);
+    }
   }
 
   void BonsoirAction::log(std::string message, std::list<std::string> parameters) {
@@ -91,6 +121,32 @@ namespace bonsoir_windows {
       eventQueue.front()->process(this);
       eventQueue.pop();
     }
+  }
+
+  void BonsoirAction::RegisterMessageWindowClass() {
+    std::call_once(gRegisterMessageWindowClassFlag, []() {
+      WNDCLASSW windowClass{};
+      windowClass.lpfnWndProc = BonsoirAction::MessageWindowProc;
+      windowClass.hInstance = GetModuleHandle(nullptr);
+      windowClass.lpszClassName = kMessageWindowClassName;
+      RegisterClassW(&windowClass);
+    });
+  }
+
+  LRESULT CALLBACK BonsoirAction::MessageWindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
+    if (message == WM_NCCREATE) {
+      const auto createStruct = reinterpret_cast<CREATESTRUCT*>(lparam);
+      SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(createStruct->lpCreateParams));
+      return TRUE;
+    }
+
+    auto action = reinterpret_cast<BonsoirAction*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+    if (message == processEventQueueMessage && action) {
+      action->processEventQueue();
+      return 0;
+    }
+
+    return DefWindowProc(hwnd, message, wparam, lparam);
   }
 
   EventObject::EventObject(std::string _message)

--- a/packages/bonsoir_windows/windows/bonsoir_action.h
+++ b/packages/bonsoir_windows/windows/bonsoir_action.h
@@ -4,6 +4,7 @@
 #include <windows.h>
 #include <windns.h>
 
+#include <atomic>
 #include <mutex>
 #include <queue>
 
@@ -104,10 +105,16 @@ namespace bonsoir_windows {
     DNS_SERVICE_CANCEL cancelHandle{};
 
    private:
+    static constexpr UINT processEventQueueMessage = WM_APP + 301;
+
+    static LRESULT CALLBACK MessageWindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam);
+    static void RegisterMessageWindowClass();
+
     void onEvent(std::shared_ptr<EventObject> eventObjectPtr, std::list<std::string> parameters);
     std::string BonsoirAction::format(std::string message, std::list<std::string> parameters);
 
     bool printLogs;
+    HWND messageWindow = nullptr;
 
     std::mutex mutex;
     std::queue<std::shared_ptr<EventObject>> eventQueue;


### PR DESCRIPTION
## Summary
Fixes Windows Bonsoir discovery event dispatch by ensuring Flutter event-channel messages are sent from the platform thread.

## Observed error
[ERROR:flutter/shell/common/shell.cc(1183)] The 'fr.skyost.bonsoir.discovery.80428' channel sent a message from native to Flutter on a non-platform thread. Platform channel messages must be sent on the platform thread. Failure to do so may result in data loss or crashes, and must be fixed in the plugin or application code creating that channel.
See https://docs.flutter.dev/platform-integration/platform-channels#channels-and-platform-threading for more information.

## Details
- Queue Bonsoir events produced by Windows DNS callbacks.
- Add a message-only HWND per action to marshal queued events back to the platform thread.
- Flush queued events from the HWND message handler before calling `EventSink::Success/Error`.
- Add `.gitattributes` to normalize line endings and avoid Windows-generated diff noise.

## Validation
- `flutter analyze packages/bonsoir_windows`
- `flutter build windows --debug` from `packages/bonsoir/example`
- Ran windows flutter app with patched bonsoir_windows, error no longer present.