### PR TITLE
fix: [Android] Apply text records to the correct service

### DIFF
--- a/packages/bonsoir_android/android/src/main/kotlin/fr/skyost/bonsoir/discovery/BonsoirServiceDiscovery.kt
+++ b/packages/bonsoir_android/android/src/main/kotlin/fr/skyost/bonsoir/discovery/BonsoirServiceDiscovery.kt
@@ -183,13 +183,20 @@ class BonsoirServiceDiscovery(
      * @param txtRecord The TXT record data instance.
      */
     private fun onServiceTxtRecordFound(service: BonsoirService, txtRecord: TxtRecordData) {
-        if (service.attributes != txtRecord.dictionary) {
-            log(
-                logMessages[Generated.discoveryTxtResolved]!!,
-                listOf(service, txtRecord.dictionary)
-            )
-            service.attributes = txtRecord.dictionary
-            onSuccess(Generated.discoveryServiceUpdated, service)
+        // Text record should be applied to the service specified by txtRecord.fqdn, not the service that sent the message
+        val txtRecordServiceName: String? = txtRecord.fqdn?.split(".", limit = 2)?.get(0)
+        if(txtRecordServiceName == null) {
+            return;
+        }
+        services.forEach {
+            if(it.name == txtRecordServiceName && it.attributes != txtRecord.dictionary) {
+                log(
+                    logMessages[Generated.discoveryTxtResolved]!!,
+                    listOf(it, txtRecord.dictionary)
+                )
+                it.attributes = txtRecord.dictionary
+                onSuccess(Generated.discoveryServiceUpdated, it)
+            }
         }
     }
 


### PR DESCRIPTION
[Android only]

If multiple services are advertising on the same network, the text records given during `BonsoirDiscoveryEvent`s are often applied to the wrong service. For example, when a new Mac was added to my network, every service advertised that it had new attributes, but they are all copied from the Mac's text records (macOS version, etc.). Since I am using text records to identify what devices are supported by my app, this causes the wrong devices to show as "supported."

This bug happens because of how text records are processed in the Android implementation. When a text record is received in `onServiceTxtRecordFound`, the `txtRecord` is applied to the `service` that sent the message; however, services will often advertise the text records of other services on the network, so the text record will apply to the wrong service. 

To apply the text records correctly, I used `txtRecord.fqdn`, which contains the FQDN for the service the text record actually applies to (example value `MyDevice._http._tcp.local`). I parsed the FQDN and applied the text records to the service with a name that matches, which fixed the issue
