### PR TITLE
fix(darwin): add missing Foundation import to access JSONSerialization

### DIFF
--- a/packages/bonsoir_darwin/darwin/bonsoir_darwin/Sources/bonsoir_darwin/BonsoirService.swift
+++ b/packages/bonsoir_darwin/darwin/bonsoir_darwin/Sources/bonsoir_darwin/BonsoirService.swift
@@ -1,4 +1,5 @@
 import Network
+import Foundation
 
 /// Represents a Bonsoir service.
 @available(iOS 13.0, macOS 10.15, *)


### PR DESCRIPTION
Fixes #132 by importing `Foundation` to access `JSONSerialization`.

Without this import (tested on macOS 15.5, Xcode Version 16.4, Swift Package Manager):

```console
error: cannot find 'JSONSerialization' in scope
            let data = try JSONSerialization.data(withJSONObject: json)
```