### PR TITLE
docs(readme): add timetout in example code snippet

### DIFF
--- a/packages/bonsoir/README.md
+++ b/packages/bonsoir/README.md
@@ -81,6 +81,9 @@ discovery.eventStream!.listen((event) { // `eventStream` is not null as the disc
 // Start the discovery **after** listening to discovery events :
 await discovery.start();
 
+// Timeout
+await Future<void>.delayed(Duration(seconds: 5));
+
 // Then if you want to stop the discovery :
 await discovery.stop();
 ```


### PR DESCRIPTION
Adds default 5 seconds timeout ([same as `multicast_dns` Dart package](https://github.com/flutter/packages/blob/main/packages/multicast_dns/lib/multicast_dns.dart#L213)).

This makes the minimal example usable, since without a timeout, the expected service may not be discovered. Being able to test the package's functionality quickly by copying and pasting the example's code snippet is useful for prototypes and when trying out different plugins.