### PR TITLE
fix(android): apply kotlin-android plugin so the kotlin {} DSL block works

### DIFF
--- a/packages/bonsoir_android/android/build.gradle
+++ b/packages/bonsoir_android/android/build.gradle
@@ -22,6 +22,7 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
 
 android {
     if (project.android.hasProperty("namespace")) {


### PR DESCRIPTION
Fixes a build error introduced in 7.x.0:
A problem occurred evaluating project ':bonsoir_android'.
> Could not find method kotlin() for arguments [...] on project ':bonsoir_android'
at android/build.gradle:59

The build script declares the Kotlin Gradle Plugin on the classpath and uses src/main/kotlin source directories, but it never applies the kotlin-android plugin. Without the plugin being applied, the kotlin { ... } DSL
extension isn't installed on the project, so Gradle treats it as an unknown method and fails configuration.
Adding apply plugin: "kotlin-android" next to the existing com.android.library application resolves the error.

fix #137 