### PR TITLE
fix(android): make discovery services list thread-safe (NPE / CME)

### DIFF
--- a/packages/bonsoir_android/android/src/main/kotlin/fr/skyost/bonsoir/discovery/BonsoirServiceDiscovery.kt
+++ b/packages/bonsoir_android/android/src/main/kotlin/fr/skyost/bonsoir/discovery/BonsoirServiceDiscovery.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
@@ -66,8 +67,14 @@ class BonsoirServiceDiscovery(
 
     /**
      * Contains all discovered services.
+     *
+     * Backed by a [CopyOnWriteArrayList] because it is written from the NSD discovery
+     * callback thread (onServiceFound/onServiceLost/dispose) while being read from the
+     * IO coroutine launched in queryTxtRecord (via findService in onServiceTxtRecordFound).
+     * A plain ArrayList exposed a transient null slot during that race, crashing with a
+     * NullPointerException on service.name in findService.
      */
-    private val services: ArrayList<BonsoirService> = ArrayList()
+    private val services: MutableList<BonsoirService> = CopyOnWriteArrayList()
 
     /**
      * Contains all active callbacks.


### PR DESCRIPTION
While debugging a production Crashlytics crash I traced a `NullPointerException` to `BonsoirServiceDiscovery.services`.

## Problem

`services` is a plain `ArrayList<BonsoirService>`:

```kotlin
private val services: ArrayList<BonsoirService> = ArrayList()
```

It is **written** from the NSD discovery callback thread (`onServiceFound`, `onServiceLost`, `dispose`) but **read** from the `Dispatchers.IO` coroutine launched in `queryTxtRecord` — `resolveTxtRecord` completes, then `onServiceTxtRecordFound` calls `findService(name, type)`, which iterates `ArrayList(services)`.

`ArrayList` is not thread-safe. When a concurrent `add`/grow happens during the defensive `ArrayList(services)` copy in `findService`, the copy can momentarily contain a `null` slot. Iterating it and evaluating `name == service.name` then dereferences `null`:

```
java.lang.NullPointerException: Attempt to invoke virtual method
  'java.lang.String fr.skyost.bonsoir.BonsoirService.getName()' on a null object reference
  at fr.skyost.bonsoir.discovery.BonsoirServiceDiscovery.findService(BonsoirServiceDiscovery.kt:117)
  at fr.skyost.bonsoir.discovery.BonsoirServiceDiscovery.onServiceTxtRecordFound(...)
  at ...invokeSuspend (BonsoirServiceDiscovery.kt) // queryTxtRecord coroutine
```

The same unsynchronized access can also surface as a `ConcurrentModificationException`. It is timing-dependent, so it is rare and device-specific (seen in production on Android 11 and 13 phones).

## Fix

Back `services` with a `CopyOnWriteArrayList`. Reads (the `findService` iteration) always see a consistent snapshot, and writes never tear the backing array. Write volume on this list is tiny (one entry per discovered service), so copy-on-write overhead is negligible.

```kotlin
private val services: MutableList<BonsoirService> = CopyOnWriteArrayList()
```

No API or behaviour change; the existing `add` / `remove` / `clear` / `ArrayList(services)` call sites are unchanged.