### PR TITLE
fix(Windows): Clean up resolving services with a mutex to prevent race conditions

### DIFF
--- a/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
@@ -84,7 +84,6 @@ namespace bonsoir_windows {
     resolveRequest.QueryName = const_cast<PWSTR>(queryName.c_str());
     resolveRequest.pResolveCompletionCallback = resolveCallback;
     resolveRequest.pQueryContext = this;
-
     DNS_STATUS status = DnsServiceResolve(&resolveRequest, resolveCancelHandle);
     if (status == DNS_REQUEST_PENDING) {
       resolvingServices[servicePtr] = resolveCancelHandle;

--- a/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
@@ -48,11 +48,14 @@ namespace bonsoir_windows {
     }
     BonsoirAction::stop();
     onSuccess(Generated::discoveryStopped, nullptr, std::list<std::string>{type});
-    for (auto const &[key, value] : resolvingServices) {
-      DnsServiceResolveCancel(value);
-      delete value; // Allocated in resolveService()
+    {
+      const std::lock_guard<std::mutex> lock(resolvingServicesCleanupMutex);
+      for (auto const &[key, value] : resolvingServices) {
+        DnsServiceResolveCancel(value);
+        delete value; // Allocated in resolveService()
+      }
+      resolvingServices.clear();
     }
-    resolvingServices.clear();
     services.clear();
     DnsServiceBrowseCancel(&cancelHandle);
   }
@@ -81,6 +84,7 @@ namespace bonsoir_windows {
     resolveRequest.QueryName = const_cast<PWSTR>(queryName.c_str());
     resolveRequest.pResolveCompletionCallback = resolveCallback;
     resolveRequest.pQueryContext = this;
+
     DNS_STATUS status = DnsServiceResolve(&resolveRequest, resolveCancelHandle);
     if (status == DNS_REQUEST_PENDING) {
       resolvingServices[servicePtr] = resolveCancelHandle;
@@ -198,6 +202,14 @@ namespace bonsoir_windows {
       serviceData = parseBonjourFqdn(nameHost);
       servicePtr = discovery->findService(std::get<0>(serviceData), std::get<1>(serviceData));
     }
+
+    if(servicePtr) {
+      const std::lock_guard<std::mutex> lock(discovery->resolvingServicesCleanupMutex);
+      DNS_SERVICE_CANCEL* resolveCancelHandle = discovery->resolvingServices[servicePtr];
+      delete resolveCancelHandle; // Allocated in resolveService()
+	    discovery->resolvingServices.erase(servicePtr);
+    }
+
     if (status != ERROR_SUCCESS) {
       if (servicePtr) {
         discovery->onSuccess(Generated::discoveryServiceResolveFailed, servicePtr, std::list<std::string>{std::to_string(status)});
@@ -224,9 +236,6 @@ namespace bonsoir_windows {
       servicePtr->port = serviceInstance->wPort;
       DnsServiceFreeInstance(serviceInstance);
     }
-    DNS_SERVICE_CANCEL* resolveCancelHandle = discovery->resolvingServices[servicePtr];
-    delete resolveCancelHandle; // Allocated in resolveService()
-    discovery->resolvingServices.erase(servicePtr);
     discovery->onSuccess(Generated::discoveryServiceResolved, servicePtr);
   }
 }  // namespace bonsoir_windows


### PR DESCRIPTION
### Problem

During discovery on a Windows machine, the app would occasionally crash with a popup indicating a heap memory error:

<img width="429" height="327" alt="windows_crash_error" src="https://github.com/user-attachments/assets/2e4dfac6-4ca4-434b-b14f-5aca5c446ad2" />

By making a small example that reproduced the crash, I found that it only happened when `resolve` was called on the same service multiple times. This lead me to figuring out the crash was caused by a race condition when freeing `resolvingServices` memory (during `resolveCallback` or `stop`). The same service resolving multiple times would cause several simultaneous calls to `resolveCallback`, which would both try to delete the same memory, causing Windows to halt the program and show the above popup.

### Solution

Adding a mutex when deleting memory for `resolvingServices`  seems to avoid the crash. Additionally, freeing the memory earlier in `resolveCallback` ensures the memory gets freed even if there is an early return.