### PR TITLE
fix(windows): declare resolvingServicesCleanupMutex in header

### DIFF
--- a/packages/bonsoir_windows/windows/bonsoir_discovery.h
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.h
@@ -8,6 +8,7 @@ namespace bonsoir_windows {
     std::string type;
     std::list<std::shared_ptr<BonsoirService>> services;
     std::map<std::shared_ptr<BonsoirService>, PDNS_SERVICE_CANCEL> resolvingServices = std::map<std::shared_ptr<BonsoirService>, PDNS_SERVICE_CANCEL>{};
+    std::mutex resolvingServicesCleanupMutex;
 
     BonsoirDiscovery(
       int _id,


### PR DESCRIPTION
Summary
This PR fixes a Windows compilation error introduced in a recent commit (which added a mutex to protect resolvingServices during cleanup in bonsoir_discovery.cpp). The mutex variable resolvingServicesCleanupMutex was used in bonsoir_discovery.cpp but was never declared in bonsoir_discovery.h.

Details of the fix
Added std::mutex resolvingServicesCleanupMutex; under class BonsoirDiscovery in packages/bonsoir_windows/windows/bonsoir_discovery.h.
Errors resolved
This resolving the following compilation errors on MSVC:

`bonsoir_discovery.cpp(52,46): error C2065: "resolvingServicesCleanupMutex": undeclared identifier
bonsoir_discovery.cpp(206,57): error C2039: "resolvingServicesCleanupMutex": is not a member of "bonsoir_windows::BonsoirDiscovery"
bonsoir_discovery.cpp(206,45): error C2512: "std::lock_guard<std::mutex>::lock_guard": no appropriate default constructor available`