### PR TITLE
fix(windows): resolve and update service attributes (TXT records) during service resolution

### DIFF
--- a/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
@@ -233,11 +233,14 @@ namespace bonsoir_windows {
         servicePtr->hostname = toUtf8(serviceInstance->pszHostName);
       }
       servicePtr->port = serviceInstance->wPort;
-      if (serviceInstance->dwPropertyCount > 0 && serviceInstance->keys != nullptr && serviceInstance->values != nullptr) {
+      if (serviceInstance->dwPropertyCount > 0 && serviceInstance->keys != nullptr) {
         for (DWORD i = 0; i < serviceInstance->dwPropertyCount; i++) {
           if (serviceInstance->keys[i] != nullptr) {
             std::string key = toUtf8(serviceInstance->keys[i]);
-            std::string value = serviceInstance->values[i] != nullptr ? toUtf8(serviceInstance->values[i]) : "";
+            std::string value = "";
+            if (serviceInstance->values != nullptr && serviceInstance->values[i] != nullptr) {
+              value = toUtf8(serviceInstance->values[i]);
+            }
             servicePtr->attributes[key] = value;
           }
         }

--- a/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
@@ -233,6 +233,15 @@ namespace bonsoir_windows {
         servicePtr->hostname = toUtf8(serviceInstance->pszHostName);
       }
       servicePtr->port = serviceInstance->wPort;
+      if (serviceInstance->dwPropertyCount > 0 && serviceInstance->keys != nullptr && serviceInstance->values != nullptr) {
+        for (DWORD i = 0; i < serviceInstance->dwPropertyCount; i++) {
+          if (serviceInstance->keys[i] != nullptr) {
+            std::string key = toUtf8(serviceInstance->keys[i]);
+            std::string value = serviceInstance->values[i] != nullptr ? toUtf8(serviceInstance->values[i]) : "";
+            servicePtr->attributes[key] = value;
+          }
+        }
+      }
       DnsServiceFreeInstance(serviceInstance);
     }
     discovery->onSuccess(Generated::discoveryServiceResolved, servicePtr);

--- a/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
+++ b/packages/bonsoir_windows/windows/bonsoir_discovery.cpp
@@ -233,6 +233,7 @@ namespace bonsoir_windows {
         servicePtr->hostname = toUtf8(serviceInstance->pszHostName);
       }
       servicePtr->port = serviceInstance->wPort;
+      servicePtr->attributes.clear();
       if (serviceInstance->dwPropertyCount > 0 && serviceInstance->keys != nullptr) {
         for (DWORD i = 0; i < serviceInstance->dwPropertyCount; i++) {
           if (serviceInstance->keys[i] != nullptr) {


### PR DESCRIPTION
### Problem
On Windows, when a service is discovered via DnsServiceBrowse, browseCallback is triggered with a PDNS_RECORD list. However, if the service's TXT record is not already cached locally by Windows, the browse callback's record list typically only contains the PTR record, resulting in empty service attributes.

Subsequently, the plugin triggers DnsServiceResolve to resolve the service. When resolveCallback is invoked, it receives a PDNS_SERVICE_INSTANCE structure containing the resolved host addresses, port, and properties (keys and values which contain the TXT records/attributes).

Currently, resolveCallback only extracts hostAddresses, hostname, and port from the resolved instance, completely ignoring the properties. As a result, if the attributes were not populated during the initial discovery phase, they remain empty even after resolution completes, causing the resolved service to lose its attributes (e.g. device name/type) on the Dart side.

### Solution
Modify the resolveCallback in bonsoir_discovery.cpp to parse the keys and values from PDNS_SERVICE_INSTANCE and populate the attributes map in the resolved BonsoirService pointer:

```cpp
if (serviceInstance) {
      servicePtr->hostAddresses = serviceInstanceIpAddresses(serviceInstance);
      if (serviceInstance->pszHostName != nullptr) {
        servicePtr->hostname = toUtf8(serviceInstance->pszHostName);
      }
      servicePtr->port = serviceInstance->wPort;
      if (serviceInstance->dwPropertyCount > 0 && serviceInstance->keys != nullptr && serviceInstance->values != nullptr) {
        for (DWORD i = 0; i < serviceInstance->dwPropertyCount; i++) {
          if (serviceInstance->keys[i] != nullptr) {
            std::string key = toUtf8(serviceInstance->keys[i]);
            std::string value = serviceInstance->values[i] != nullptr ? toUtf8(serviceInstance->values[i]) : "";
            servicePtr->attributes[key] = value;
          }
        }
      }
      DnsServiceFreeInstance(serviceInstance);
    }
```


   
This ensures that service attributes (such as custom metadata/device name) are always correctly resolved and populated, eliminating the issue where discovered devices sometimes show up with empty attributes.