### PR TITLE
chore(docs): Updated docs to clarify that `hostAddress` can also be an IPv6 address.

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -212,6 +212,13 @@ by checking the `BonsoirDiscovery.supportsMdnsHostname` property. This does not 
 operating system can resolve `.local` hostnames natively for HTTP requests or sockets; use
 `hostAddresses` when you need already-resolved network addresses.
 
+The address family is also platform and service dependent. The list may contain IPv4 addresses,
+IPv6 addresses, or both. For example, Linux/Avahi may report IPv6 link-local addresses such as
+`fe80::...` for services published on the same host. Do not assume that `hostAddress` is IPv4 or
+that a raw address string can be passed directly as a URI authority. Parse or classify the address
+first, and when building URIs prefer `Uri(scheme: ..., host: address, port: ...)` or bracket IPv6
+addresses according to URI rules.
+
 If you're transitioning from `multicast_dns`, note that types don't end with <q>.local</q>.
 
 # In-depth example

--- a/packages/bonsoir/README.md
+++ b/packages/bonsoir/README.md
@@ -99,6 +99,14 @@ If you want a <q>full</q> example, don't hesitate to check [this one](https://gi
 > guarantee that the operating system can resolve `.local` hostnames natively for
 > HTTP requests or sockets; use `hostAddresses` when you need already-resolved
 > network addresses.
+>
+> The address family is platform and service dependent. The list may contain
+> IPv4 addresses, IPv6 addresses, or both, and Linux/Avahi may report IPv6
+> link-local addresses such as `fe80::...` for services published on the same
+> host. Do not assume that `hostAddress` is IPv4 or that a raw address string can
+> be passed directly as a URI authority. Parse or classify the address first, and
+> when building URIs prefer `Uri(scheme: ..., host: address, port: ...)` or
+> bracket IPv6 addresses according to URI rules.
 
 ## Contributions
 

--- a/packages/bonsoir_platform_interface/lib/src/service/service.dart
+++ b/packages/bonsoir_platform_interface/lib/src/service/service.dart
@@ -55,6 +55,10 @@ class BonsoirService {
   ///
   /// Your service should be reachable at the given host addresses.
   /// These should be IP addresses when the platform provides them.
+  /// The list may contain IPv4 addresses, IPv6 addresses, or both depending on
+  /// the platform, network interfaces, and service publisher. For example,
+  /// Linux/Avahi may expose IPv6 link-local addresses for local services.
+  /// Treat these values as raw addresses rather than URI authorities.
   /// This field may be empty if the service has not been resolved yet.
   final List<String> hostAddresses;
 
@@ -133,6 +137,8 @@ class BonsoirService {
 
   /// The first service host address.
   ///
+  /// This may be an IPv4 or IPv6 address depending on the resolved service and
+  /// platform. Do not assume that it can be passed directly as a URI authority.
   /// This field may be null if the service has not been resolved yet.
   String? get hostAddress => hostAddresses.firstOrNull;
 


### PR DESCRIPTION
This PR updates docs related to the `hostAddress` field that can contain IPv4 and IPv6 addresses as well. See #145 for more details.

Closes #145.